### PR TITLE
primer: remote data registrations

### DIFF
--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -99,6 +99,46 @@ All turtle, shapetree and shex code snippets in this primer will assume followin
 
 ## alice.example
 
+### WebID Document
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/alice.example.ttl
+  highlight: turtle
+  show: 3-100
+  </pre>
+  <figcaption>Alice's WebID document</figcaption>
+</figure>
+
+### Registrar and Registry Set
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/6a86be7b-3f60-4cc5-8ab9-f259693700d3.ttl
+  highlight: turtle
+  show: 3-100
+  </pre>
+  <figcaption>Alice's Registrar</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/ba4da3ec-dea4-41b2-be02-e4bf7a9477df.ttl
+  highlight: turtle
+  show: 3-100
+  </pre>
+  <figcaption>Alice's Remote Data Registry Set</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/6f6e4241-75a2-4780-9b2a-40da53082e54.ttl
+  highlight: turtle
+  show: 3-100
+  </pre>
+  <figcaption>Alice's Remote Data Registry</figcaption>
+</figure>
+
 ### Data Registrations
 
 <figure>
@@ -117,6 +157,33 @@ All turtle, shapetree and shex code snippets in this primer will assume followin
   show: 3-100
   </pre>
   <figcaption>Alice's data registration for tasks</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/33caf7be-f804-4155-a57a-92216c577bd4.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's remote data registration for projects @ acme.example</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/c8d29dce-eb5b-4894-9e4a-02781dbfcba3.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's remote data instance for P1 @ acme.example</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/alice.example/a3859644-a71c-4a41-b253-d0cce25a0126.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's remote data instance for P3 @ acme.example</figcaption>
 </figure>
 
 ## bob.example

--- a/proposals/primer/snippets/alice.example/33caf7be-f804-4155-a57a-92216c577bd4.ttl
+++ b/proposals/primer/snippets/alice.example/33caf7be-f804-4155-a57a-92216c577bd4.ttl
@@ -1,0 +1,24 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix trees: <https://solidshapes.example/trees/> .
+@prefix acme: <https://acme.example/> .
+@prefix alice: <https://alice.example/> .
+
+alice:33caf7be-f804-4155-a57a-92216c577bd4
+  a interop:RemoteDataRegistration ;
+  interop:registeredBy <https://alice.example/#id> ;
+  interop:registeredWith <https://jarvis.alice.example/#agent> ;
+  interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:providedAt "2020-09-05T06:16:01Z"^^xsd:dateTime ;
+  interop:hasDataReceipt
+    alice:23dd1856-ac91-4acb-85ce-7f335057c8ae ;
+  interop:hasRegistration
+    acme:f201471d-b1fb-40ad-9eac-867aaf09c3e5 ;
+  interop:registeredShapeTree trees:Project ;
+  interop:scopeOfDataGrant interop:SelectedInstances ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:hasRemoteDataInstance
+    alice:c8d29dce-eb5b-4894-9e4a-02781dbfcba3 ,
+    alice:a3859644-a71c-4a41-b253-d0cce25a0126 . 

--- a/proposals/primer/snippets/alice.example/6a86be7b-3f60-4cc5-8ab9-f259693700d3.ttl
+++ b/proposals/primer/snippets/alice.example/6a86be7b-3f60-4cc5-8ab9-f259693700d3.ttl
@@ -1,0 +1,7 @@
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix alice: <https://alice.example/> .
+
+alice:6a86be7b-3f60-4cc5-8ab9-f259693700d3
+  a interop:Registrar ;
+  interop:hasRemoteDataRegistrySet
+    alice:ba4da3ec-dea4-41b2-be02-e4bf7a9477df .

--- a/proposals/primer/snippets/alice.example/6f6e4241-75a2-4780-9b2a-40da53082e54.ttl
+++ b/proposals/primer/snippets/alice.example/6f6e4241-75a2-4780-9b2a-40da53082e54.ttl
@@ -1,0 +1,7 @@
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix alice: <https://alice.example/> .
+
+alice:6f6e4241-75a2-4780-9b2a-40da53082e54
+  a interop:RemoteDataRegistry ;
+  interop:hasRegistration
+    alice:33caf7be-f804-4155-a57a-92216c577bd4 .

--- a/proposals/primer/snippets/alice.example/a3859644-a71c-4a41-b253-d0cce25a0126.ttl
+++ b/proposals/primer/snippets/alice.example/a3859644-a71c-4a41-b253-d0cce25a0126.ttl
@@ -1,0 +1,18 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix trees: <https://solidshapes.example/trees/> .
+@prefix acme: <https://acme.example/> .
+@prefix alice: <https://alice.example/> .
+
+alice:a3859644-a71c-4a41-b253-d0cce25a0126
+  a interop:RemoteDataInstance ;
+  interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:providedAt "2020-09-05T06:16:01Z"^^xsd:dateTime ;
+  interop:hasDataReceipt
+    alice:23dd1856-ac91-4acb-85ce-7f335057c8ae ;
+  interop:registeredShapeTree trees:Project ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:hasRegisteredDataInstance
+    acme:21270a16-f07d-417e-9d7c-274cbd8d24f0\#project .

--- a/proposals/primer/snippets/alice.example/alice.example.ttl
+++ b/proposals/primer/snippets/alice.example/alice.example.ttl
@@ -1,0 +1,7 @@
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix alice: <https://alice.example/> .
+
+alice:\#id
+  a interop:Agent ;
+  interop:hasRegistrar
+    alice:6a86be7b-3f60-4cc5-8ab9-f259693700d3 .

--- a/proposals/primer/snippets/alice.example/ba4da3ec-dea4-41b2-be02-e4bf7a9477df.ttl
+++ b/proposals/primer/snippets/alice.example/ba4da3ec-dea4-41b2-be02-e4bf7a9477df.ttl
@@ -1,0 +1,7 @@
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix alice: <https://alice.example/> .
+
+alice:ba4da3ec-dea4-41b2-be02-e4bf7a9477df
+  a interop:RemoteDataRegistrySet ;
+  interop:hasRegistry
+    alice:6f6e4241-75a2-4780-9b2a-40da53082e54 .

--- a/proposals/primer/snippets/alice.example/c8d29dce-eb5b-4894-9e4a-02781dbfcba3.ttl
+++ b/proposals/primer/snippets/alice.example/c8d29dce-eb5b-4894-9e4a-02781dbfcba3.ttl
@@ -1,0 +1,18 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix interop: <http://www.w3.org/ns/solid/interop#> .
+@prefix trees: <https://solidshapes.example/trees/> .
+@prefix acme: <https://acme.example/> .
+@prefix alice: <https://alice.example/> .
+
+alice:c8d29dce-eb5b-4894-9e4a-02781dbfcba3
+  a interop:RemoteDataInstance ;
+  interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:providedAt "2020-09-05T06:16:01Z"^^xsd:dateTime ;
+  interop:hasDataReceipt
+    alice:23dd1856-ac91-4acb-85ce-7f335057c8ae ;
+  interop:registeredShapeTree trees:Project ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:hasRegisteredDataInstance
+    acme:9005ea66-fcc3-47af-b082-5da78140bc53\#project .

--- a/proposals/primer/snippets/prefixes.ttl
+++ b/proposals/primer/snippets/prefixes.ttl
@@ -7,3 +7,6 @@
 @prefix shapes: <https://solidshapes.example/shapes/> .
 @prefix trees: <https://solidshapes.example/trees/> .
 @prefix ex: <https://namespace.example/> .
+@prefix acme: <https://acme.example/> .
+@prefix alice: <https://alice.example/> .
+@prefix bob: <https://bob.example/> .


### PR DESCRIPTION
since access to tasks is inherited from access to projects, do we need remote data instances for all the tasks of all the projects?