### PR TITLE
application discovers public resources known by the user

### DIFF
--- a/proposals/ucr/index.bs
+++ b/proposals/ucr/index.bs
@@ -201,10 +201,10 @@ grants Acme's customer group read acecss to analytic reports.
 ### Application can discover publicly accessible resources already known by the user
 
 Bob cultivates various interests and contributes to many independent wikis,
-including cocoascript.example, airwall.example, frogman.example etc.
-Bob have discovered new application to edit wiki pages wikitor.example,
+including cocoascript.example, airwall.example, frogman.example, etc.
+Bob discovers a new application to edit wiki pages, wikitor.example, and
 he authorizes it to read and write wiki pages on his behalf. Bob expects
-that wikitor will find all the wiki pages he alredy contributed to.
+that wikitor will find all the wiki pages to which he has already contributed.
 
 Requirements {#requirements}
 ================================================================================

--- a/proposals/ucr/index.bs
+++ b/proposals/ucr/index.bs
@@ -196,9 +196,9 @@ access to analytic reports, so it can distribute them to Acme customers.
 Acme also allows their customers to access analytic reports directly. Eric
 grants Acme's customer group read acecss to analytic reports.
 
-## Data Discovery
+## Data Discovery ## {#discovery}
 
-### Application can discover publicly accessible resources already known by the user
+### Application can discover publicly accessible resources already known by the user ### {#public-discovery}
 
 Bob cultivates various interests and contributes to many independent wikis,
 including cocoascript.example, airwall.example, frogman.example, etc.

--- a/proposals/ucr/index.bs
+++ b/proposals/ucr/index.bs
@@ -198,7 +198,7 @@ grants Acme's customer group read acecss to analytic reports.
 
 ## Data Discovery
 
-### Application can discover publicly accessible resources already know by the user
+### Application can discover publicly accessible resources already known by the user
 
 Bob cultivates various interests and contributes to many independent wikis,
 including cocoascript.example, airwall.example, frogman.example etc.

--- a/proposals/ucr/index.bs
+++ b/proposals/ucr/index.bs
@@ -196,5 +196,15 @@ access to analytic reports, so it can distribute them to Acme customers.
 Acme also allows their customers to access analytic reports directly. Eric
 grants Acme's customer group read acecss to analytic reports.
 
+## Data Discovery
+
+### Application can discover publicly accessible resources already know by the user
+
+Bob cultivates various interests and contributes to many independent wikis,
+including cocoascript.example, airwall.example, frogman.example etc.
+Bob have discovered new application to edit wiki pages wikitor.example,
+he authorizes it to read and write wiki pages on his behalf. Bob expects
+that wikitor will find all the wiki pages he alredy contributed to.
+
 Requirements {#requirements}
 ================================================================================


### PR DESCRIPTION
This UC tries to capture case where user doesn't get access receipt since resource is editable by public (or authorized agent). At the same time user wants to keep track of resources they have edited and expect new applications which work with those resources to discover them.