### PR TITLE
first sequence diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 proposals/**/index.html
 proposals/**/notes.md
+proposals/**/*.mmd.svg
 .on-save.json
+
+node_modules
+package-lock.json
+yarn.lock

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+for bsdoc in proposals/**/*.bs; do bikeshed spec $bsdoc; done
+for diagram in proposals/**/*.mmd; do npx mmdc -i $diagram; done

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-for bsdoc in proposals/**/*.bs; do bikeshed spec $bsdoc; done
+for bsdoc in proposals/**/index.bs; do bikeshed spec $bsdoc; done
 for diagram in proposals/**/*.mmd; do npx mmdc -i $diagram; done

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "data-interoperability-panel",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@mermaid-js/mermaid-cli": "^8.9.2"
+  }
+}

--- a/proposals/primer/diagrams/idp-aa-combined-external-storage.mmd
+++ b/proposals/primer/diagrams/idp-aa-combined-external-storage.mmd
@@ -1,0 +1,58 @@
+sequenceDiagram
+    autonumber
+    participant App as Application (Client)
+    participant OPAA as Alice's OIDC Provider & Authorization Agent
+    participant AlicePod as Alice's Pod
+    participant AcmePod as ACME's Pod
+    participant AppID as Application's WebID Document
+    participant WebID as Alice's WebID Document
+    note over App: 👩 Alice enters her WebID
+    App ->> WebID: Resolve Alice's WebID
+    WebID ->> App: Alice's WebID Document
+    note over App: Discovers Alice's OIDC Provider and Authorization Agent from WebID Document
+    App -->> OPAA: Initiate Solid-OIDC via redirect
+    opt No active session with OP
+    note over OPAA: 👩 Alice authenticates with OP
+    end
+    OPAA ->> AppID: Resolve Application's WebID
+    AppID ->> OPAA: Application's WebID Document
+    OPAA ->> AlicePod: Fetch application registration 🗝️
+    opt No existing registration
+    AlicePod ->> OPAA: 404 Not Found
+    OPAA ->> AlicePod: Create application registration 🗝️
+    end
+    AlicePod ->> OPAA: Application Registration
+    note over OPAA: Authorization Agent finds Access Needs in Application's WebID Document
+    note over OPAA: 👩 Alice grants access via consent screen based on Access Needs
+    note over OPAA: Authorization Agent generates Access Grant and Access Receipt
+    OPAA ->> AlicePod: Store Access Grant in Access Grants Registry 🗝️
+    OPAA ->> AlicePod: Store Access Receipt in Application Registration 🗝️
+    OPAA -->> App: Redirect with authorization code
+    App ->> OPAA: Exchanges code for ID Token and (🔑 ) Access Token
+    note over App: ⚠️ Application uses WebID from ID Token
+    note over App: Application discovers its registration from ID Token
+    App ->> AlicePod: Fetch Application Registration 🔑
+    AlicePod ->> App: Application Registration
+    App ->> AlicePod: Fetch Access Receipt 🔑
+    AlicePod ->> App: Access Receipt
+    opt data grants in separate resources
+      loop for each data grant IRI
+        App ->> AlicePod: Fetch Data Grant 🔑
+        AlicePod ->> App: Data Grant
+      end
+    end
+    opt live update
+      note over App: 🔑 Application subscribes for live updates to its registration
+    end
+    App ->> AlicePod: Fetch Project A 🔑
+    AlicePod ->> App: Project A Document
+    loop for each Task in Project A
+      App ->> AlicePod: Fetch Task 🔑
+      AlicePod ->> App: Task Document
+    end
+    App ->> AcmePod: Fetch Project 1 🔑
+    AcmePod ->> App: Project 1 Document
+    loop for each Task in Project 1
+      App ->> AcmePod: Fetch Task 🔑
+      AcmePod ->> App: Task Document
+    end

--- a/proposals/primer/diagrams/idp-aa-combined.mmd
+++ b/proposals/primer/diagrams/idp-aa-combined.mmd
@@ -22,15 +22,21 @@ sequenceDiagram
     note over OPAA: 👩 Alice grants access via consent screen based on Access Needs
     note over OPAA: Authorization Agent records Access Grants and updates Application Registration
     OPAA -->> App: Redirect with authorization code
-    App ->> OPAA: Exchanges code for ID Token and Access Token
+    App ->> OPAA: Exchanges code for ID Token and Access Token 🔑
     note over App: ⚠️ Application uses WebID from ID Token
     note over App: Application discovers its registration from ID Token
+    App ->> OPAA: Fetch Application Registration 🔑
+    OPAA ->> App: Application Registration
+    App ->> OPAA: Fetch Access Receipt 🔑
+    OPAA ->> App: Access Receipt
+    opt data grants in separate resources
+      loop for each data grant IRI
+        App ->> OPAA: Fetch Data Grant 🔑
+        OPAA ->> App: Data Grant
+      end
+    end
     opt live update
-      note over App: Application subscribes for live updates to its registration
+      note over App: 🔑 Application subscribes for live updates to its registration
     end
-    loop initially and on each update
-      App ->> OPAA: Fetch Application Registration with Access Receipt
-      OPAA ->> App: Application Registration with Access Receipt
-    end
-    App ->> Pod: Fetch Project 1 (uses access token)
+    App ->> Pod: Fetch Project 1 🔑
     Pod ->> App: Project 1 Document

--- a/proposals/primer/diagrams/idp-aa-combined.mmd
+++ b/proposals/primer/diagrams/idp-aa-combined.mmd
@@ -1,0 +1,36 @@
+sequenceDiagram
+    autonumber
+    participant App as Application (Client)
+    participant OPAA as Alice's OIDC Provider & Authorization Agent
+    participant AppID as Application's WebID Document
+    participant WebID as Alice's WebID Document
+    participant Pod as ACME's Pod
+    note over App: 👩 Alice enters her WebID
+    App ->> WebID: Resolve Alice's WebID
+    WebID ->> App: Alice's WebID Document
+    note over App: Discovers Alice's OIDC Provider and Authorization Agent from WebID Document
+    App -->> OPAA: Initiate Solid-OIDC via redirect
+    opt No active session with OP
+    note over OPAA: 👩 Alice authenticates with OP
+    end
+    opt No existing registration
+    note over OPAA: Creates Application Registration
+    end
+    OPAA ->> AppID: Resolve Application's WebID
+    AppID ->> OPAA: Application's WebID Document
+    note over OPAA: Authorization Agent finds Access Needs in Application's WebID Document
+    note over OPAA: 👩 Alice grants access via consent screen based on Access Needs
+    note over OPAA: Authorization Agent records Access Grants and updates Application Registration
+    OPAA -->> App: Redirect with authorization code
+    App ->> OPAA: Exchanges code for ID Token and Access Token
+    note over App: ⚠️ Application uses WebID from ID Token
+    note over App: Application discovers its registration from ID Token
+    opt live update
+      note over App: Application subscribes for live updates to its registration
+    end
+    loop initially and on each update
+      App ->> OPAA: Fetch Application Registration with Access Receipt
+      OPAA ->> App: Application Registration with Access Receipt
+    end
+    App ->> Pod: Fetch Project 1 (uses access token)
+    Pod ->> App: Project 1 Document

--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -267,3 +267,7 @@ All ShExC code snippets will asssume
 #### Authorization Agent stores Registrations and Grants
 
 <img class="sequence-diagram" src="diagrams/idp-aa-combined.mmd.svg" />
+
+#### Authorization Agent gets Registrations and Grants from Storage
+
+<img class="sequence-diagram" src="diagrams/idp-aa-combined-external-storage.mmd.svg" />

--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -9,6 +9,14 @@ Editor: elf Pavlik
 Abstract: Primer for the Solid interoperability.
 </pre>
 
+<style>
+
+  .sequence-diagram {
+    max-width: 100%;
+  }
+
+</style>
+
 Introduction
 =====================
 
@@ -251,3 +259,11 @@ All ShExC code snippets will asssume
   </pre>
   <figcaption>PerformChart's application profile document</figcaption>
 </figure>
+
+## Sequence diagrams
+
+### Combined OIDC Provider and Authorization Agent
+
+#### Authorization Agent stores Registrations and Grants
+
+<img class="sequence-diagram" src="diagrams/idp-aa-combined.mmd.svg" />


### PR DESCRIPTION
This PR starts addressing #93 

Deployment preview will not work on this PR so I'm including copy of rendered diagram below

![Screen Shot 2021-05-07 at 13 52 36](https://user-images.githubusercontent.com/876431/117495640-8a1cb300-af3b-11eb-9ca9-baa3d5ae4362.png)


I include IMO simplest deployment which combines OIDC Provide and Authorization Agent, as well as includes small storage and can handle registrations and grants internally. This gives user just one consent screen and removes network chatter between authorization agent and storage.

I plan to add other variants in later PR
* Authorization Agent connects to external storage with registrations and grants
* Separate OIDC Provider and Authorization Agent (user gets two consent screens, one from each)