### PR TITLE
Add elf Pavlik as Editor

### DIFF
--- a/proposals/specification/index.bs
+++ b/proposals/specification/index.bs
@@ -10,7 +10,7 @@ Repository: https://github.com/solid/data-interoperability-panel
 Inline Github Issues: title
 Editor: Justin Bingham
 Editor: Eric Prud'hommeaux
-Editor: Josh Collins
+Editor: elf Pavlik
 Markup Shorthands: markdown yes
 Boilerplate: style-darkmode off
 Abstract:


### PR DESCRIPTION
This PR adds @elf-pavlik as editor, to formalize a role that he has been performing already for a number of months, during which time he's identified and demonstrated through implementation a number of essential improvements and optimizations. It also removes @joshdcollins, who has elected to move on from his editorial role, and does so with thanks and appreciation for countless essential contributions!