### PR TITLE
Delegated grants, dataOwner and iriPrefix

### DIFF
--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -668,6 +668,26 @@ Issue(solid/data-interoperability-panel#131):
 
 ## auth.alice.example
 
+### Access Consent
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/329eb90a-feb9-4c95-a427-2ef23989abe9.ttl
+  highlight: turtle
+  show: 7-100
+  </pre>
+  <figcaption>Alice's access consent for Projectron - Omni's NA Projects</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/fe442ef3-5200-4b06-b4bc-fc0b495603a9.ttl
+  highlight: turtle
+  show: 6-100
+  </pre>
+  <figcaption>Alice's access consent for Projectron - Omni's NA Tasks</figcaption>
+</figure>
+
 ### Access Grant Registry
 
 <figure>
@@ -746,20 +766,20 @@ Issue(solid/data-interoperability-panel#131):
 
 <figure>
   <pre class=include-code>
-  path: snippets/auth.alice.example/329eb90a-feb9-4c95-a427-2ef23989abe9.ttl
+  path: snippets/auth.alice.example/92328851-ffb0-427d-847e-f6d9c8417648.ttl
   highlight: turtle
-  show: 7-100
+  show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for Projectron - Omni's Projects</figcaption>
+  <figcaption>Alice's remote data grant for Projectron - Omni's NA Projects</figcaption>
 </figure>
 
 <figure>
   <pre class=include-code>
-  path: snippets/auth.alice.example/fe442ef3-5200-4b06-b4bc-fc0b495603a9.ttl
+  path: snippets/auth.alice.example/a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8.ttl
   highlight: turtle
-  show: 6-100
+  show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for Projectron - Omni's Tasks</figcaption>
+  <figcaption>Alice's remote data grant for Projectron - Omni's NA Tasks</figcaption>
 </figure>
 
 <figure>

--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -706,6 +706,24 @@ Issue(solid/data-interoperability-panel#131):
   <figcaption>Alice's access consent for Projectron - Omni's NA Tasks</figcaption>
 </figure>
 
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/a691ee69-97d8-45c0-bb03-8e887b2db806.ttl
+  highlight: turtle
+  show: 6-100
+  </pre>
+  <figcaption>Alice's data consent for PerformChart - Projects</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/ecdf7b5e-5123-4a93-87bc-86ef6de389ff.ttl
+  highlight: turtle
+  show: 6-100
+  </pre>
+  <figcaption>Alice's data consent for PerformChart - Tasks</figcaption>
+</figure>
+
 ### Access Grant Registry
 
 <figure>
@@ -829,22 +847,57 @@ Issue(solid/data-interoperability-panel#131):
 
 <figure>
   <pre class=include-code>
-  path: snippets/auth.alice.example/a691ee69-97d8-45c0-bb03-8e887b2db806.ttl
+  path: snippets/auth.alice.example/995eda6f-1567-41de-b55a-97260e6b38d9.ttl
   highlight: turtle
-  show: 6-100
+  show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for PerformChart - Projects</figcaption>
+  <figcaption>Alice's delegated data grant for PerformChart - ACME's RnD Projects</figcaption>
 </figure>
 
 <figure>
   <pre class=include-code>
-  path: snippets/auth.alice.example/ecdf7b5e-5123-4a93-87bc-86ef6de389ff.ttl
+  path: snippets/auth.alice.example/d8f282b3-4a0e-4093-90d1-169cf7a090e8.ttl
   highlight: turtle
-  show: 6-100
+  show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for PerformChart - Tasks</figcaption>
+  <figcaption>Alice's delegated data grant for PerformChart - ACME's Finance Projects</figcaption>
 </figure>
 
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/1d2e21fb-b8be-4ca7-acf7-13bf2340801f.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's delegated data grant for PerformChart - RnD ACME's Tasks</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's delegated data grant for PerformChart - Finance ACME's Tasks</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/ae7564dd-73f7-490a-9a0b-76215ffca9d3.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's delegated data grant for PerformChart - Omni's NA Projects</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/0978d42e-3eb3-4137-9c7f-160759e77860.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's delegated data grant for PerformChart - Omni's NA Tasks</figcaption>
+</figure>
 
 ### Application Registry
 

--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -828,7 +828,7 @@ Issue(solid/data-interoperability-panel#131):
   <pre class=include-code>
   path: snippets/auth.alice.example/b6c24b2a-3d4c-4518-8c1f-d739a51cca0d.ttl
   highlight: turtle
-  show: 10-100
+  show: 6-100
   </pre>
   <figcaption>Alice's access receipt from ACME</figcaption>
 </figure>
@@ -837,7 +837,7 @@ Issue(solid/data-interoperability-panel#131):
   <pre class=include-code>
   path: snippets/auth.alice.example/7b065498-fa43-4abd-a08b-467d49f3cac8.ttl
   highlight: turtle
-  show: 9-100
+  show: 6-100
   </pre>
   <figcaption>Alice's access receipt from Omni</figcaption>
 </figure>
@@ -846,7 +846,7 @@ Issue(solid/data-interoperability-panel#131):
   <pre class=include-code>
   path: snippets/auth.alice.example/dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe.ttl
   highlight: turtle
-  show: 8-100
+  show: 5-100
   </pre>
   <figcaption>Alice's access receipt for Projectron</figcaption>
 </figure>

--- a/proposals/primer/index.bs
+++ b/proposals/primer/index.bs
@@ -672,6 +672,24 @@ Issue(solid/data-interoperability-panel#131):
 
 <figure>
   <pre class=include-code>
+  path: snippets/auth.alice.example/e2765d6c-848a-4fc0-9092-556903730263.ttl
+  highlight: turtle
+  show: 6-100
+  </pre>
+  <figcaption>Alice's data consent for Projectron - ACME's Projects</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/6a9feb57-252b-43b2-8470-5a938888b2fa.ttl
+  highlight: turtle
+  show: 6-100
+  </pre>
+  <figcaption>Alice's data consent for Projectron - ACME's Tasks</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
   path: snippets/auth.alice.example/329eb90a-feb9-4c95-a427-2ef23989abe9.ttl
   highlight: turtle
   show: 7-100
@@ -748,20 +766,38 @@ Issue(solid/data-interoperability-panel#131):
 
 <figure>
   <pre class=include-code>
-  path: snippets/auth.alice.example/e2765d6c-848a-4fc0-9092-556903730263.ttl
+  path: snippets/auth.alice.example/12daf870-a343-4684-b828-c67c5c9c997a.ttl
   highlight: turtle
-  show: 6-100
+  show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for Projectron - ACME's Projects</figcaption>
+  <figcaption>Alice's delegated data grant for Projectron - ACME's RnD Projects</figcaption>
 </figure>
 
 <figure>
   <pre class=include-code>
-  path: snippets/auth.alice.example/6a9feb57-252b-43b2-8470-5a938888b2fa.ttl
+  path: snippets/auth.alice.example/7be5a39f-583d-4464-8ad8-a39e24b99fce.ttl
   highlight: turtle
-  show: 6-100
+  show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for Projectron - ACME's Tasks</figcaption>
+  <figcaption>Alice's delegated data grant for Projectron - ACME's Finance Projects</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/c205e9da-2dc5-4d1f-8be9-a3f90c13eedc.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's delegated data grant for Projectron - RnD ACME's Tasks</figcaption>
+</figure>
+
+<figure>
+  <pre class=include-code>
+  path: snippets/auth.alice.example/68dd1212-b0f3-4611-aae2-f9f5ea30ee07.ttl
+  highlight: turtle
+  show: 8-100
+  </pre>
+  <figcaption>Alice's delegated data grant for Projectron - Finance ACME's Tasks</figcaption>
 </figure>
 
 <figure>
@@ -770,7 +806,7 @@ Issue(solid/data-interoperability-panel#131):
   highlight: turtle
   show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for Projectron - Omni's NA Projects</figcaption>
+  <figcaption>Alice's delegated data grant for Projectron - Omni's NA Projects</figcaption>
 </figure>
 
 <figure>
@@ -779,7 +815,7 @@ Issue(solid/data-interoperability-panel#131):
   highlight: turtle
   show: 8-100
   </pre>
-  <figcaption>Alice's remote data grant for Projectron - Omni's NA Tasks</figcaption>
+  <figcaption>Alice's delegated data grant for Projectron - Omni's NA Tasks</figcaption>
 </figure>
 
 <figure>

--- a/proposals/primer/snippets/auth.acme.example/6e069259-7836-4495-ba35-fc7eca97e5aa.ttl
+++ b/proposals/primer/snippets/auth.acme.example/6e069259-7836-4495-ba35-fc7eca97e5aa.ttl
@@ -6,6 +6,7 @@ PREFIX acme-finance: <https://finance.acme.example/>
 
 acme-auth:6e069259-7836-4495-ba35-fc7eca97e5aa
   a interop:DataGrant ;
+    interop:dataOwner <https://acme.example/#corp> ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:hasDataRegistration acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.acme.example/6e069259-7836-4495-ba35-fc7eca97e5aa.ttl
+++ b/proposals/primer/snippets/auth.acme.example/6e069259-7836-4495-ba35-fc7eca97e5aa.ttl
@@ -13,3 +13,6 @@ acme-auth:6e069259-7836-4495-ba35-fc7eca97e5aa
     interop:scopeOfGrant interop:InheritInstances ;
     interop:inheritsFromGrant
       acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264 .
+
+acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad
+  interop:iriPrefix "https://finance.acme.example/" .

--- a/proposals/primer/snippets/auth.acme.example/80ef3361-730b-4f7c-93ba-4a4415de7264.ttl
+++ b/proposals/primer/snippets/auth.acme.example/80ef3361-730b-4f7c-93ba-4a4415de7264.ttl
@@ -6,6 +6,7 @@ PREFIX acme-finance: <https://finance.acme.example/>
 
 acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264
   a interop:DataGrant ;
+    interop:dataOwner <https://acme.example/#corp> ;
     interop:registeredShapeTree solidtrees:Project ;
     interop:hasDataRegistration acme-finance:882eea27-b968-44e7-b8f5-87b234089057 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.acme.example/80ef3361-730b-4f7c-93ba-4a4415de7264.ttl
+++ b/proposals/primer/snippets/auth.acme.example/80ef3361-730b-4f7c-93ba-4a4415de7264.ttl
@@ -14,3 +14,6 @@ acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264
 acme-auth:6e069259-7836-4495-ba35-fc7eca97e5aa
     interop:inheritsFromGrant
       acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264 .
+
+acme-finance:882eea27-b968-44e7-b8f5-87b234089057
+  interop:iriPrefix "https://finance.acme.example/" .

--- a/proposals/primer/snippets/auth.acme.example/cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e.ttl
+++ b/proposals/primer/snippets/auth.acme.example/cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e.ttl
@@ -6,6 +6,7 @@ PREFIX acme-rnd: <https://rnd.acme.example/>
 
 acme-auth:cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e
   a interop:DataGrant ;
+    interop:dataOwner <https://acme.example/#corp> ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:hasDataRegistration acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.acme.example/cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e.ttl
+++ b/proposals/primer/snippets/auth.acme.example/cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e.ttl
@@ -13,3 +13,6 @@ acme-auth:cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e
     interop:scopeOfGrant interop:InheritInstances ;
     interop:inheritsFromGrant
       acme-auth:f8064946-cb67-469a-8b28-652fd17090f6 .
+
+acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539
+  interop:iriPrefix "https://rnd.acme.example/" .

--- a/proposals/primer/snippets/auth.acme.example/f8064946-cb67-469a-8b28-652fd17090f6.ttl
+++ b/proposals/primer/snippets/auth.acme.example/f8064946-cb67-469a-8b28-652fd17090f6.ttl
@@ -11,6 +11,10 @@ acme-auth:f8064946-cb67-469a-8b28-652fd17090f6
     interop:hasDataRegistration acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475 ;
     interop:accessMode acl:Read, acl:Write ;
     interop:scopeOfGrant interop:AllInstances .
+
 acme-auth:cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e
     interop:inheritsFromGrant
       acme-auth:f8064946-cb67-469a-8b28-652fd17090f6 .
+
+acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475
+  interop:iriPrefix "https://rnd.acme.example/" .

--- a/proposals/primer/snippets/auth.acme.example/f8064946-cb67-469a-8b28-652fd17090f6.ttl
+++ b/proposals/primer/snippets/auth.acme.example/f8064946-cb67-469a-8b28-652fd17090f6.ttl
@@ -6,6 +6,7 @@ PREFIX acme-rnd: <https://rnd.acme.example/>
 
 acme-auth:f8064946-cb67-469a-8b28-652fd17090f6
   a interop:DataGrant ;
+    interop:dataOwner <https://acme.example/#corp> ;
     interop:registeredShapeTree solidtrees:Project ;
     interop:hasDataRegistration acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.alice.example/0978d42e-3eb3-4137-9c7f-160759e77860.ttl
+++ b/proposals/primer/snippets/auth.alice.example/0978d42e-3eb3-4137-9c7f-160759e77860.ttl
@@ -10,7 +10,7 @@ alice-auth:0978d42e-3eb3-4137-9c7f-160759e77860
   interop:dataOwner <https://omni.example/#corp> ;
   interop:registeredShapeTree solidtrees:Task ;
   interop:hasDataRegistration omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3 ;
-  interop:accessMode acl:Read, acl:Write ;
+  interop:accessMode acl:Read ;
   interop:scopeOfGrant interop:InheritInstances ;
   interop:delegationOfGrant
     omni-auth:73c5f23c-099e-452e-ab29-cbfc8c8a19f8 ;

--- a/proposals/primer/snippets/auth.alice.example/0978d42e-3eb3-4137-9c7f-160759e77860.ttl
+++ b/proposals/primer/snippets/auth.alice.example/0978d42e-3eb3-4137-9c7f-160759e77860.ttl
@@ -1,0 +1,21 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX omni-auth: <https://auth.omni.example/>
+PREFIX omni-na: <https://na.omni.example/>
+
+alice-auth:0978d42e-3eb3-4137-9c7f-160759e77860
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://omni.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Task ;
+  interop:hasDataRegistration omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:InheritInstances ;
+  interop:delegationOfGrant
+    omni-auth:73c5f23c-099e-452e-ab29-cbfc8c8a19f8 ;
+  interop:inheritsFromGrant
+    alice-auth:ae7564dd-73f7-490a-9a0b-76215ffca9d3 .
+
+omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3
+  interop:iriPrefix "https://na.omni.example/" .

--- a/proposals/primer/snippets/auth.alice.example/12daf870-a343-4684-b828-c67c5c9c997a.ttl
+++ b/proposals/primer/snippets/auth.alice.example/12daf870-a343-4684-b828-c67c5c9c997a.ttl
@@ -1,0 +1,23 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-rnd: <https://rnd.acme.example/>
+
+alice-auth:12daf870-a343-4684-b828-c67c5c9c997a
+  a interop:DelegatedDataGrant ;
+    interop:dataOwner <https://acme.example/#corp> ;
+    interop:registeredShapeTree solidtrees:Project ;
+    interop:hasDataRegistration acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475 ;
+    interop:accessMode acl:Read, acl:Write ;
+    interop:scopeOfGrant interop:AllInstances ;
+    interop:delegationOfGrant
+      acme-auth:f8064946-cb67-469a-8b28-652fd17090f6 .
+
+alice-auth:c205e9da-2dc5-4d1f-8be9-a3f90c13eedc
+    interop:inheritsFromGrant
+      alice-auth:12daf870-a343-4684-b828-c67c5c9c997a .
+
+acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475
+  interop:iriPrefix "https://rnd.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/170c12ac-7d4f-47fe-b36d-7a9944c429d9.ttl
+++ b/proposals/primer/snippets/auth.alice.example/170c12ac-7d4f-47fe-b36d-7a9944c429d9.ttl
@@ -8,5 +8,5 @@ alice-auth:170c12ac-7d4f-47fe-b36d-7a9944c429d9
     interop:registeredWith <https://jarvis.alice.example/#agent> ;
     interop:registeredAt "2020-04-04T20:15:47.000Z"^^xsd:dateTime ;
     interop:updatedAt "2020-04-04T21:11:33.000Z"^^xsd:dateTime ;
-    interop:registeredApplication <https://performchat.example/#app> ;
+    interop:registeredApplication <https://performchart.example/#app> ;
     interop:hasAccessReceipt alice-auth:7b513402-d2a2-455f-a6d1-4a54ef90cb78 .

--- a/proposals/primer/snippets/auth.alice.example/1d2e21fb-b8be-4ca7-acf7-13bf2340801f.ttl
+++ b/proposals/primer/snippets/auth.alice.example/1d2e21fb-b8be-4ca7-acf7-13bf2340801f.ttl
@@ -1,0 +1,21 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-rnd: <https://rnd.acme.example/>
+
+alice-auth:1d2e21fb-b8be-4ca7-acf7-13bf2340801f
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://acme.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Task ;
+  interop:hasDataRegistration acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:InheritInstances ;
+  interop:delegationOfGrant
+    acme-auth:cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e ;
+  interop:inheritsFromGrant
+    alice-auth:995eda6f-1567-41de-b55a-97260e6b38d9 .
+
+acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539
+  interop:iriPrefix "https://rnd.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/1d2e21fb-b8be-4ca7-acf7-13bf2340801f.ttl
+++ b/proposals/primer/snippets/auth.alice.example/1d2e21fb-b8be-4ca7-acf7-13bf2340801f.ttl
@@ -10,7 +10,7 @@ alice-auth:1d2e21fb-b8be-4ca7-acf7-13bf2340801f
   interop:dataOwner <https://acme.example/#corp> ;
   interop:registeredShapeTree solidtrees:Task ;
   interop:hasDataRegistration acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539 ;
-  interop:accessMode acl:Read, acl:Write ;
+  interop:accessMode acl:Read ;
   interop:scopeOfGrant interop:InheritInstances ;
   interop:delegationOfGrant
     acme-auth:cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e ;

--- a/proposals/primer/snippets/auth.alice.example/329eb90a-feb9-4c95-a427-2ef23989abe9.ttl
+++ b/proposals/primer/snippets/auth.alice.example/329eb90a-feb9-4c95-a427-2ef23989abe9.ttl
@@ -5,13 +5,13 @@ PREFIX alice-auth: <https://auth.alice.example/>
 PREFIX omni-auth: <https://auth.omni.example/>
 
 alice-auth:329eb90a-feb9-4c95-a427-2ef23989abe9
-  a interop:RemoteDataGrant ;
+  a interop:DataConsent ;
     interop:registeredShapeTree solidtrees:Project ;
-    interop:hasRemoteDataFromAgent alice-auth:19479afc-00b9-4f7b-b602-9cc612d4b9cf ;
     interop:accessMode acl:Read, acl:Write ;
-    interop:scopeOfGrant interop:SelectedRemote ;
-    interop:hasDataGrant
+    interop:onDataOwnedBy <https://omni.example/#corp> ;
+    interop:scopeOfConsent interop:SelectedRemote ;
+    interop:selectedDataGrant
       omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce .
 alice-auth:fe442ef3-5200-4b06-b4bc-fc0b495603a9
-    interop:inheritsFromGrant
+    interop:inheritsFromConsent
       alice-auth:329eb90a-feb9-4c95-a427-2ef23989abe9 .

--- a/proposals/primer/snippets/auth.alice.example/3fcef0f6-5807-4f1b-b77a-63d64df25a69.ttl
+++ b/proposals/primer/snippets/auth.alice.example/3fcef0f6-5807-4f1b-b77a-63d64df25a69.ttl
@@ -17,8 +17,8 @@ alice-auth:3fcef0f6-5807-4f1b-b77a-63d64df25a69
       alice-auth:54b1a123-23ca-4733-9371-700b52b9c567 ,
       alice-auth:e2765d6c-848a-4fc0-9092-556903730263 ,
       alice-auth:6a9feb57-252b-43b2-8470-5a938888b2fa ,
-      alice-auth:329eb90a-feb9-4c95-a427-2ef23989abe9 ,
-      alice-auth:fe442ef3-5200-4b06-b4bc-fc0b495603a9 .
+      alice-auth:92328851-ffb0-427d-847e-f6d9c8417648 ,
+      alice-auth:a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8 .
 
 <#grant-subject>
   a interop:AccessGrantSubject ;

--- a/proposals/primer/snippets/auth.alice.example/3fcef0f6-5807-4f1b-b77a-63d64df25a69.ttl
+++ b/proposals/primer/snippets/auth.alice.example/3fcef0f6-5807-4f1b-b77a-63d64df25a69.ttl
@@ -15,8 +15,10 @@ alice-auth:3fcef0f6-5807-4f1b-b77a-63d64df25a69
       alice-auth:9827ae00-2778-4655-9f22-08bb9daaee26 ,
       alice-auth:7b2bc4ff-b4b8-47b8-96f6-06695f4c5126 ,
       alice-auth:54b1a123-23ca-4733-9371-700b52b9c567 ,
-      alice-auth:e2765d6c-848a-4fc0-9092-556903730263 ,
-      alice-auth:6a9feb57-252b-43b2-8470-5a938888b2fa ,
+      alice-auth:12daf870-a343-4684-b828-c67c5c9c997a ,
+      alice-auth:7be5a39f-583d-4464-8ad8-a39e24b99fce ,
+      alice-auth:c205e9da-2dc5-4d1f-8be9-a3f90c13eedc ,
+      alice-auth:68dd1212-b0f3-4611-aae2-f9f5ea30ee07 ,
       alice-auth:92328851-ffb0-427d-847e-f6d9c8417648 ,
       alice-auth:a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8 .
 

--- a/proposals/primer/snippets/auth.alice.example/54b1a123-23ca-4733-9371-700b52b9c567.ttl
+++ b/proposals/primer/snippets/auth.alice.example/54b1a123-23ca-4733-9371-700b52b9c567.ttl
@@ -6,6 +6,7 @@ PREFIX alice-home: <https://home.alice.example/>
 
 alice-auth:54b1a123-23ca-4733-9371-700b52b9c567
   a interop:DataGrant ;
+    interop:dataOwner <https://alice.example/#id> ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:hasDataRegistration alice-home:92f43be4-d12c-4ca3-9bd6-c18e83167b2f ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.alice.example/54b1a123-23ca-4733-9371-700b52b9c567.ttl
+++ b/proposals/primer/snippets/auth.alice.example/54b1a123-23ca-4733-9371-700b52b9c567.ttl
@@ -13,3 +13,6 @@ alice-auth:54b1a123-23ca-4733-9371-700b52b9c567
     interop:scopeOfGrant interop:InheritInstances ;
     interop:inheritsFromGrant
       alice-auth:7b2bc4ff-b4b8-47b8-96f6-06695f4c5126 .
+
+alice-home:92f43be4-d12c-4ca3-9bd6-c18e83167b2f
+  interop:iriPrefix "https://home.alice.example/" .

--- a/proposals/primer/snippets/auth.alice.example/68dd1212-b0f3-4611-aae2-f9f5ea30ee07.ttl
+++ b/proposals/primer/snippets/auth.alice.example/68dd1212-b0f3-4611-aae2-f9f5ea30ee07.ttl
@@ -1,0 +1,21 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-finance: <https://finance.acme.example/>
+
+alice-auth:68dd1212-b0f3-4611-aae2-f9f5ea30ee07
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://acme.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Task ;
+  interop:hasDataRegistration acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:InheritInstances ;
+  interop:delegationOfGrant
+    acme-auth:6e069259-7836-4495-ba35-fc7eca97e5aa ;
+  interop:inheritsFromGrant
+    alice-auth:7be5a39f-583d-4464-8ad8-a39e24b99fce .
+
+acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad
+  interop:iriPrefix "https://finance.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/6a9feb57-252b-43b2-8470-5a938888b2fa.ttl
+++ b/proposals/primer/snippets/auth.alice.example/6a9feb57-252b-43b2-8470-5a938888b2fa.ttl
@@ -4,9 +4,10 @@ PREFIX solidtrees: <https://solidshapes.example/trees/>
 PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:6a9feb57-252b-43b2-8470-5a938888b2fa
-  a interop:RemoteDataGrant ;
+  a interop:DataConsent ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:accessMode acl:Read, acl:Write ;
+    interop:onDataOwnedBy <https://acme.example/#corp> ;
     interop:scopeOfGrant interop:InheritRemoteInstances ;
-    interop:inheritsFromGrant
+    interop:inheritsFromConsent
       alice-auth:e2765d6c-848a-4fc0-9092-556903730263 .

--- a/proposals/primer/snippets/auth.alice.example/6b1b6e39-75e4-44f8-84f3-104b1a8210ad.ttl
+++ b/proposals/primer/snippets/auth.alice.example/6b1b6e39-75e4-44f8-84f3-104b1a8210ad.ttl
@@ -20,4 +20,4 @@ alice-auth:6b1b6e39-75e4-44f8-84f3-104b1a8210ad
 <#grant-subject>
   a interop:AccessGrantSubject ;
   interop:accessByAgent  <https://alice.example/#id> ;
-  interop:accessByApplication <https://performchat.example/#app> .
+  interop:accessByApplication <https://performchart.example/#app> .

--- a/proposals/primer/snippets/auth.alice.example/6b1b6e39-75e4-44f8-84f3-104b1a8210ad.ttl
+++ b/proposals/primer/snippets/auth.alice.example/6b1b6e39-75e4-44f8-84f3-104b1a8210ad.ttl
@@ -4,16 +4,20 @@ PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:6b1b6e39-75e4-44f8-84f3-104b1a8210ad
   a interop:AccessGrant ;
-    interop:registeredBy <https://alice.example/#id> ;
-    interop:registeredWith <https://jarvis.alice.example/#agent> ;
-    interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
-    interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
-    interop:hasAccessGrantSubject <#grant-subject> ;
-    interop:hasDataGrant
-      alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806 ,
-      alice-auth:ecdf7b5e-5123-4a93-87bc-86ef6de389ff .
+  interop:registeredBy <https://alice.example/#id> ;
+  interop:registeredWith <https://jarvis.alice.example/#agent> ;
+  interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:hasAccessGrantSubject <#grant-subject> ;
+  interop:hasDataGrant
+    alice-auth:995eda6f-1567-41de-b55a-97260e6b38d9 ,
+    alice-auth:d8f282b3-4a0e-4093-90d1-169cf7a090e8 ,
+    alice-auth:1d2e21fb-b8be-4ca7-acf7-13bf2340801f ,
+    alice-auth:cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2 ,
+    alice-auth:ae7564dd-73f7-490a-9a0b-76215ffca9d3 ,
+    alice-auth:0978d42e-3eb3-4137-9c7f-160759e77860 .
 
 <#grant-subject>
   a interop:AccessGrantSubject ;
-    interop:accessByAgent  <https://alice.example/#id> ;
-    interop:accessByApplication <https://performchat.example/#app> .
+  interop:accessByAgent  <https://alice.example/#id> ;
+  interop:accessByApplication <https://performchat.example/#app> .

--- a/proposals/primer/snippets/auth.alice.example/7b065498-fa43-4abd-a08b-467d49f3cac8.ttl
+++ b/proposals/primer/snippets/auth.alice.example/7b065498-fa43-4abd-a08b-467d49f3cac8.ttl
@@ -1,9 +1,6 @@
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX acl: <http://www.w3.org/ns/auth/acl#>
 PREFIX interop: <http://www.w3.org/ns/solid/interop#>
-PREFIX solidtrees: <https://solidshapes.example/trees/>
 PREFIX omni-auth: <https://auth.omni.example/>
-PREFIX omni-na: <https://na.omni.example/>
 PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:7b065498-fa43-4abd-a08b-467d49f3cac8

--- a/proposals/primer/snippets/auth.alice.example/7b2bc4ff-b4b8-47b8-96f6-06695f4c5126.ttl
+++ b/proposals/primer/snippets/auth.alice.example/7b2bc4ff-b4b8-47b8-96f6-06695f4c5126.ttl
@@ -11,6 +11,10 @@ alice-auth:7b2bc4ff-b4b8-47b8-96f6-06695f4c5126
     interop:hasDataRegistration alice-home:f6ccd3a4-45ea-4f98-8a36-98eac92a6720 ;
     interop:accessMode acl:Read, acl:Write ;
     interop:scopeOfGrant interop:AllInstances .
+
 alice-auth:54b1a123-23ca-4733-9371-700b52b9c567
     interop:inheritsFromGrant
       alice-auth:7b2bc4ff-b4b8-47b8-96f6-06695f4c5126 .
+
+alice-home:f6ccd3a4-45ea-4f98-8a36-98eac92a6720
+  interop:iriPrefix "https://home.alice.example/" .

--- a/proposals/primer/snippets/auth.alice.example/7b2bc4ff-b4b8-47b8-96f6-06695f4c5126.ttl
+++ b/proposals/primer/snippets/auth.alice.example/7b2bc4ff-b4b8-47b8-96f6-06695f4c5126.ttl
@@ -6,6 +6,7 @@ PREFIX alice-home: <https://home.alice.example/>
 
 alice-auth:7b2bc4ff-b4b8-47b8-96f6-06695f4c5126
   a interop:DataGrant ;
+    interop:dataOwner <https://alice.example/#id> ;
     interop:registeredShapeTree solidtrees:Project ;
     interop:hasDataRegistration alice-home:f6ccd3a4-45ea-4f98-8a36-98eac92a6720 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.alice.example/7b513402-d2a2-455f-a6d1-4a54ef90cb78.ttl
+++ b/proposals/primer/snippets/auth.alice.example/7b513402-d2a2-455f-a6d1-4a54ef90cb78.ttl
@@ -6,17 +6,21 @@ PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:7b513402-d2a2-455f-a6d1-4a54ef90cb78
   a interop:AccessReceipt ;
-    interop:registeredBy <https://alice.example/#id> ;
-    interop:registeredWith <https://jarvis.alice.example/#agent> ;
-    interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
-    interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
-    interop:hasAccessGrantSubject
-      alice-auth:6b1b6e39-75e4-44f8-84f3-104b1a8210ad\#grant-subject ;
-    interop:hasDataGrant
-      alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806 ,
-      alice-auth:ecdf7b5e-5123-4a93-87bc-86ef6de389ff .
+  interop:registeredBy <https://alice.example/#id> ;
+  interop:registeredWith <https://jarvis.alice.example/#agent> ;
+  interop:registeredAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:updatedAt "2020-09-05T06:15:01Z"^^xsd:dateTime ;
+  interop:hasAccessGrantSubject
+    alice-auth:6b1b6e39-75e4-44f8-84f3-104b1a8210ad\#grant-subject ;
+  interop:hasDataGrant
+    alice-auth:995eda6f-1567-41de-b55a-97260e6b38d9 ,
+    alice-auth:d8f282b3-4a0e-4093-90d1-169cf7a090e8 ,
+    alice-auth:1d2e21fb-b8be-4ca7-acf7-13bf2340801f ,
+    alice-auth:cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2 ,
+    alice-auth:ae7564dd-73f7-490a-9a0b-76215ffca9d3 ,
+    alice-auth:0978d42e-3eb3-4137-9c7f-160759e77860 .
 
 alice-auth:6b1b6e39-75e4-44f8-84f3-104b1a8210ad\#grant-subject
   a interop:AccessGrantSubject ;
-    interop:accessByAgent  <https://alice.example/#id> ;
-    interop:accessByApplication <https://performchat.example/#app> .
+  interop:accessByAgent  <https://alice.example/#id> ;
+  interop:accessByApplication <https://performchat.example/#app> .

--- a/proposals/primer/snippets/auth.alice.example/7b513402-d2a2-455f-a6d1-4a54ef90cb78.ttl
+++ b/proposals/primer/snippets/auth.alice.example/7b513402-d2a2-455f-a6d1-4a54ef90cb78.ttl
@@ -23,4 +23,4 @@ alice-auth:7b513402-d2a2-455f-a6d1-4a54ef90cb78
 alice-auth:6b1b6e39-75e4-44f8-84f3-104b1a8210ad\#grant-subject
   a interop:AccessGrantSubject ;
   interop:accessByAgent  <https://alice.example/#id> ;
-  interop:accessByApplication <https://performchat.example/#app> .
+  interop:accessByApplication <https://performchart.example/#app> .

--- a/proposals/primer/snippets/auth.alice.example/7be5a39f-583d-4464-8ad8-a39e24b99fce.ttl
+++ b/proposals/primer/snippets/auth.alice.example/7be5a39f-583d-4464-8ad8-a39e24b99fce.ttl
@@ -1,0 +1,23 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-finance: <https://finance.acme.example/>
+
+alice-auth:7be5a39f-583d-4464-8ad8-a39e24b99fce
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://acme.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Project ;
+  interop:hasDataRegistration acme-finance:882eea27-b968-44e7-b8f5-87b234089057 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:AllInstances ;
+  interop:delegationOfGrant
+    acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264 .
+
+alice-auth:68dd1212-b0f3-4611-aae2-f9f5ea30ee07
+  interop:inheritsFromGrant
+    alice-auth:7be5a39f-583d-4464-8ad8-a39e24b99fce .
+
+acme-finance:882eea27-b968-44e7-b8f5-87b234089057
+  interop:iriPrefix "https://finance.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/92328851-ffb0-427d-847e-f6d9c8417648.ttl
+++ b/proposals/primer/snippets/auth.alice.example/92328851-ffb0-427d-847e-f6d9c8417648.ttl
@@ -1,0 +1,23 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX omni-auth: <https://auth.omni.example/>
+PREFIX omni-na: <https://na.omni.example/>
+
+alice-auth:92328851-ffb0-427d-847e-f6d9c8417648
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://omni.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Project ;
+  interop:hasDataRegistration omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:AllInstances ;
+  interop:delegationOfGrant
+    omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce .
+
+alice-auth:a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8
+  interop:inheritsFromGrant
+    alice-auth:92328851-ffb0-427d-847e-f6d9c8417648 .
+
+omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140
+  interop:iriPrefix "https://na.omni.example/" .

--- a/proposals/primer/snippets/auth.alice.example/9827ae00-2778-4655-9f22-08bb9daaee26.ttl
+++ b/proposals/primer/snippets/auth.alice.example/9827ae00-2778-4655-9f22-08bb9daaee26.ttl
@@ -6,6 +6,7 @@ PREFIX alice-pro: <https://pro.alice.example/>
 
 alice-auth:9827ae00-2778-4655-9f22-08bb9daaee26
   a interop:DataGrant ;
+    interop:dataOwner <https://alice.example/#id> ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:hasDataRegistration alice-pro:4d594c61-7cff-484a-a1d2-1f353ee4e1e7 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.alice.example/9827ae00-2778-4655-9f22-08bb9daaee26.ttl
+++ b/proposals/primer/snippets/auth.alice.example/9827ae00-2778-4655-9f22-08bb9daaee26.ttl
@@ -13,3 +13,6 @@ alice-auth:9827ae00-2778-4655-9f22-08bb9daaee26
     interop:scopeOfGrant interop:InheritInstances ;
     interop:inheritsFromGrant
       alice-auth:cd247a67-0879-4301-abd0-828f63abb252 .
+
+alice-pro:4d594c61-7cff-484a-a1d2-1f353ee4e1e7
+  interop:iriPrefix "https://pro.alice.example/" .

--- a/proposals/primer/snippets/auth.alice.example/995eda6f-1567-41de-b55a-97260e6b38d9.ttl
+++ b/proposals/primer/snippets/auth.alice.example/995eda6f-1567-41de-b55a-97260e6b38d9.ttl
@@ -10,7 +10,7 @@ alice-auth:995eda6f-1567-41de-b55a-97260e6b38d9
   interop:dataOwner <https://acme.example/#corp> ;
   interop:registeredShapeTree solidtrees:Project ;
   interop:hasDataRegistration acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475 ;
-  interop:accessMode acl:Read, acl:Write ;
+  interop:accessMode acl:Read ;
   interop:scopeOfGrant interop:AllInstances ;
   interop:delegationOfGrant
     acme-auth:f8064946-cb67-469a-8b28-652fd17090f6 .

--- a/proposals/primer/snippets/auth.alice.example/995eda6f-1567-41de-b55a-97260e6b38d9.ttl
+++ b/proposals/primer/snippets/auth.alice.example/995eda6f-1567-41de-b55a-97260e6b38d9.ttl
@@ -1,0 +1,23 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-rnd: <https://rnd.acme.example/>
+
+alice-auth:995eda6f-1567-41de-b55a-97260e6b38d9
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://acme.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Project ;
+  interop:hasDataRegistration acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:AllInstances ;
+  interop:delegationOfGrant
+    acme-auth:f8064946-cb67-469a-8b28-652fd17090f6 .
+
+alice-auth:1d2e21fb-b8be-4ca7-acf7-13bf2340801f
+  interop:inheritsFromGrant
+    alice-auth:995eda6f-1567-41de-b55a-97260e6b38d9 .
+
+acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475
+  interop:iriPrefix "https://rnd.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8.ttl
+++ b/proposals/primer/snippets/auth.alice.example/a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8.ttl
@@ -1,0 +1,21 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX omni-auth: <https://auth.omni.example/>
+PREFIX omni-na: <https://na.omni.example/>
+
+alice-auth:a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://omni.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Task ;
+  interop:hasDataRegistration omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:InheritInstances ;
+  interop:delegationOfGrant
+    omni-auth:73c5f23c-099e-452e-ab29-cbfc8c8a19f8 ;
+  interop:inheritsFromGrant
+    alice-auth:92328851-ffb0-427d-847e-f6d9c8417648 .
+
+omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3
+  interop:iriPrefix "https://na.omni.example/" .

--- a/proposals/primer/snippets/auth.alice.example/a691ee69-97d8-45c0-bb03-8e887b2db806.ttl
+++ b/proposals/primer/snippets/auth.alice.example/a691ee69-97d8-45c0-bb03-8e887b2db806.ttl
@@ -4,11 +4,10 @@ PREFIX solidtrees: <https://solidshapes.example/trees/>
 PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806
-  a interop:RemoteDataGrant ;
-    interop:registeredShapeTree solidtrees:Project ;
-    interop:hasRemoteDataRegistration alice-auth:33caf7be-f804-4155-a57a-92216c577bd4 ;
-    interop:accessMode acl:Read ;
-    interop:scopeOfGrant interop:AllRemote .
+  a interop:DataConsent ;
+  interop:registeredShapeTree solidtrees:Project ;
+  interop:accessMode acl:Read ;
+  interop:scopeOfConsent interop:AllRemote .
 alice-auth:ecdf7b5e-5123-4a93-87bc-86ef6de389ff
-    interop:inheritsFromGrant
-      alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806 .
+  interop:inheritsFromConsent
+    alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806 .

--- a/proposals/primer/snippets/auth.alice.example/ae7564dd-73f7-490a-9a0b-76215ffca9d3.ttl
+++ b/proposals/primer/snippets/auth.alice.example/ae7564dd-73f7-490a-9a0b-76215ffca9d3.ttl
@@ -1,0 +1,23 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX omni-auth: <https://auth.omni.example/>
+PREFIX omni-na: <https://na.omni.example/>
+
+alice-auth:ae7564dd-73f7-490a-9a0b-76215ffca9d3
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://omni.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Project ;
+  interop:hasDataRegistration omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:AllInstances ;
+  interop:delegationOfGrant
+    omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce .
+
+alice-auth:0978d42e-3eb3-4137-9c7f-160759e77860
+  interop:inheritsFromGrant
+    alice-auth:ae7564dd-73f7-490a-9a0b-76215ffca9d3 .
+
+omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140
+  interop:iriPrefix "https://na.omni.example/" .

--- a/proposals/primer/snippets/auth.alice.example/ae7564dd-73f7-490a-9a0b-76215ffca9d3.ttl
+++ b/proposals/primer/snippets/auth.alice.example/ae7564dd-73f7-490a-9a0b-76215ffca9d3.ttl
@@ -10,7 +10,7 @@ alice-auth:ae7564dd-73f7-490a-9a0b-76215ffca9d3
   interop:dataOwner <https://omni.example/#corp> ;
   interop:registeredShapeTree solidtrees:Project ;
   interop:hasDataRegistration omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140 ;
-  interop:accessMode acl:Read, acl:Write ;
+  interop:accessMode acl:Read ;
   interop:scopeOfGrant interop:AllInstances ;
   interop:delegationOfGrant
     omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce .

--- a/proposals/primer/snippets/auth.alice.example/c205e9da-2dc5-4d1f-8be9-a3f90c13eedc.ttl
+++ b/proposals/primer/snippets/auth.alice.example/c205e9da-2dc5-4d1f-8be9-a3f90c13eedc.ttl
@@ -1,0 +1,21 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-rnd: <https://rnd.acme.example/>
+
+alice-auth:c205e9da-2dc5-4d1f-8be9-a3f90c13eedc
+  a interop:DelegatedDataGrant ;
+    interop:dataOwner <https://acme.example/#corp> ;
+    interop:registeredShapeTree solidtrees:Task ;
+    interop:hasDataRegistration acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539 ;
+    interop:accessMode acl:Read, acl:Write ;
+    interop:scopeOfGrant interop:InheritInstances ;
+    interop:delegationOfGrant
+      acme-auth:cafafd6f-9cc6-4a5d-9cbd-8eeea95d3d4e ;
+    interop:inheritsFromGrant
+      alice-auth:12daf870-a343-4684-b828-c67c5c9c997a .
+
+acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539
+  interop:iriPrefix "https://rnd.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2.ttl
+++ b/proposals/primer/snippets/auth.alice.example/cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2.ttl
@@ -10,7 +10,7 @@ alice-auth:cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2
   interop:dataOwner <https://acme.example/#corp> ;
   interop:registeredShapeTree solidtrees:Task ;
   interop:hasDataRegistration acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad ;
-  interop:accessMode acl:Read, acl:Write ;
+  interop:accessMode acl:Read ;
   interop:scopeOfGrant interop:InheritInstances ;
   interop:delegationOfGrant
     acme-auth:6e069259-7836-4495-ba35-fc7eca97e5aa ;

--- a/proposals/primer/snippets/auth.alice.example/cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2.ttl
+++ b/proposals/primer/snippets/auth.alice.example/cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2.ttl
@@ -1,0 +1,21 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-finance: <https://finance.acme.example/>
+
+alice-auth:cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://acme.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Task ;
+  interop:hasDataRegistration acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:InheritInstances ;
+  interop:delegationOfGrant
+    acme-auth:6e069259-7836-4495-ba35-fc7eca97e5aa ;
+  interop:inheritsFromGrant
+    alice-auth:d8f282b3-4a0e-4093-90d1-169cf7a090e8 .
+
+acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad
+  interop:iriPrefix "https://finance.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/cd247a67-0879-4301-abd0-828f63abb252.ttl
+++ b/proposals/primer/snippets/auth.alice.example/cd247a67-0879-4301-abd0-828f63abb252.ttl
@@ -13,6 +13,10 @@ alice-auth:cd247a67-0879-4301-abd0-828f63abb252
     interop:scopeOfGrant interop:SelectedInstances ;
     interop:hasDataInstance
       alice-pro:7a130c38-668a-4775-821a-08b38f2306fb\#project .
+
 alice-auth:9827ae00-2778-4655-9f22-08bb9daaee26
     interop:inheritsFromGrant
       alice-auth:cd247a67-0879-4301-abd0-828f63abb252 .
+
+alice-pro:773605f0-b5bf-4d46-878d-5c167eac8b5d
+  interop:iriPrefix "https://pro.alice.example/" .

--- a/proposals/primer/snippets/auth.alice.example/cd247a67-0879-4301-abd0-828f63abb252.ttl
+++ b/proposals/primer/snippets/auth.alice.example/cd247a67-0879-4301-abd0-828f63abb252.ttl
@@ -6,6 +6,7 @@ PREFIX alice-pro: <https://pro.alice.example/>
 
 alice-auth:cd247a67-0879-4301-abd0-828f63abb252
   a interop:DataGrant ;
+    interop:dataOwner <https://alice.example/#id> ;
     interop:registeredShapeTree solidtrees:Project ;
     interop:hasDataRegistration alice-pro:773605f0-b5bf-4d46-878d-5c167eac8b5d ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.alice.example/d8f282b3-4a0e-4093-90d1-169cf7a090e8.ttl
+++ b/proposals/primer/snippets/auth.alice.example/d8f282b3-4a0e-4093-90d1-169cf7a090e8.ttl
@@ -10,7 +10,7 @@ alice-auth:d8f282b3-4a0e-4093-90d1-169cf7a090e8
   interop:dataOwner <https://acme.example/#corp> ;
   interop:registeredShapeTree solidtrees:Project ;
   interop:hasDataRegistration acme-finance:882eea27-b968-44e7-b8f5-87b234089057 ;
-  interop:accessMode acl:Read, acl:Write ;
+  interop:accessMode acl:Read ;
   interop:scopeOfGrant interop:AllInstances ;
   interop:delegationOfGrant
     acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264 .

--- a/proposals/primer/snippets/auth.alice.example/d8f282b3-4a0e-4093-90d1-169cf7a090e8.ttl
+++ b/proposals/primer/snippets/auth.alice.example/d8f282b3-4a0e-4093-90d1-169cf7a090e8.ttl
@@ -1,0 +1,23 @@
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX solidtrees: <https://solidshapes.example/trees/>
+PREFIX alice-auth: <https://auth.alice.example/>
+PREFIX acme-auth: <https://auth.acme.example/>
+PREFIX acme-finance: <https://finance.acme.example/>
+
+alice-auth:d8f282b3-4a0e-4093-90d1-169cf7a090e8
+  a interop:DelegatedDataGrant ;
+  interop:dataOwner <https://acme.example/#corp> ;
+  interop:registeredShapeTree solidtrees:Project ;
+  interop:hasDataRegistration acme-finance:882eea27-b968-44e7-b8f5-87b234089057 ;
+  interop:accessMode acl:Read, acl:Write ;
+  interop:scopeOfGrant interop:AllInstances ;
+  interop:delegationOfGrant
+    acme-auth:80ef3361-730b-4f7c-93ba-4a4415de7264 .
+
+alice-auth:cb7b6b70-2c62-4ec6-88b8-b20ffb42d0b2
+  interop:inheritsFromGrant
+    alice-auth:d8f282b3-4a0e-4093-90d1-169cf7a090e8 .
+
+acme-finance:882eea27-b968-44e7-b8f5-87b234089057
+  interop:iriPrefix "https://finance.acme.example/" .

--- a/proposals/primer/snippets/auth.alice.example/dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe.ttl
+++ b/proposals/primer/snippets/auth.alice.example/dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe.ttl
@@ -21,8 +21,8 @@ alice-auth:dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe
       alice-auth:54b1a123-23ca-4733-9371-700b52b9c567 ,
       alice-auth:e2765d6c-848a-4fc0-9092-556903730263 ,
       alice-auth:6a9feb57-252b-43b2-8470-5a938888b2fa ,
-      alice-auth:329eb90a-feb9-4c95-a427-2ef23989abe9 ,
-      alice-auth:fe442ef3-5200-4b06-b4bc-fc0b495603a9 .
+      alice-auth:92328851-ffb0-427d-847e-f6d9c8417648 ,
+      alice-auth:a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8 .
 
 alice-auth:3fcef0f6-5807-4f1b-b77a-63d64df25a69\#grant-subject
   a interop:AccessGrantSubject ;

--- a/proposals/primer/snippets/auth.alice.example/dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe.ttl
+++ b/proposals/primer/snippets/auth.alice.example/dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe.ttl
@@ -19,8 +19,10 @@ alice-auth:dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe
       alice-auth:9827ae00-2778-4655-9f22-08bb9daaee26 ,
       alice-auth:7b2bc4ff-b4b8-47b8-96f6-06695f4c5126 ,
       alice-auth:54b1a123-23ca-4733-9371-700b52b9c567 ,
-      alice-auth:e2765d6c-848a-4fc0-9092-556903730263 ,
-      alice-auth:6a9feb57-252b-43b2-8470-5a938888b2fa ,
+      alice-auth:12daf870-a343-4684-b828-c67c5c9c997a ,
+      alice-auth:7be5a39f-583d-4464-8ad8-a39e24b99fce ,
+      alice-auth:c205e9da-2dc5-4d1f-8be9-a3f90c13eedc ,
+      alice-auth:68dd1212-b0f3-4611-aae2-f9f5ea30ee07 ,
       alice-auth:92328851-ffb0-427d-847e-f6d9c8417648 ,
       alice-auth:a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8 .
 

--- a/proposals/primer/snippets/auth.alice.example/e2765d6c-848a-4fc0-9092-556903730263.ttl
+++ b/proposals/primer/snippets/auth.alice.example/e2765d6c-848a-4fc0-9092-556903730263.ttl
@@ -4,11 +4,11 @@ PREFIX solidtrees: <https://solidshapes.example/trees/>
 PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:e2765d6c-848a-4fc0-9092-556903730263
-  a interop:RemoteDataGrant ;
+  a interop:DataConsent ;
     interop:registeredShapeTree solidtrees:Project ;
-    interop:hasRemoteDataFromAgent alice-auth:3a019d90-c7fb-4e65-865d-4254ef064667 ;
+    interop:onDataOwnedBy <https://acme.example/#corp> ;
     interop:accessMode acl:Read, acl:Write ;
-    interop:scopeOfGrant interop:AllRemoteFromAgent .
+    interop:scopeOfConsent interop:AllRemoteFromAgent .
 alice-auth:6a9feb57-252b-43b2-8470-5a938888b2fa
-    interop:inheritsFromGrant
+    interop:inheritsFromConsent
       alice-auth:e2765d6c-848a-4fc0-9092-556903730263 .

--- a/proposals/primer/snippets/auth.alice.example/ecdf7b5e-5123-4a93-87bc-86ef6de389ff.ttl
+++ b/proposals/primer/snippets/auth.alice.example/ecdf7b5e-5123-4a93-87bc-86ef6de389ff.ttl
@@ -4,9 +4,9 @@ PREFIX solidtrees: <https://solidshapes.example/trees/>
 PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:ecdf7b5e-5123-4a93-87bc-86ef6de389ff
-  a interop:RemoteDataGrant ;
-    interop:registeredShapeTree solidtrees:Task ;
-    interop:accessMode acl:Read ;
-    interop:scopeOfGrant interop:InheritRemoteInstances ;
-    interop:inheritsFromGrant
-      alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806 .
+  a interop:DataConsent ;
+  interop:registeredShapeTree solidtrees:Task ;
+  interop:accessMode acl:Read ;
+  interop:scopeOfConsent interop:InheritRemoteInstances ;
+  interop:inheritsFromConsent
+    alice-auth:a691ee69-97d8-45c0-bb03-8e887b2db806 .

--- a/proposals/primer/snippets/auth.alice.example/fe442ef3-5200-4b06-b4bc-fc0b495603a9.ttl
+++ b/proposals/primer/snippets/auth.alice.example/fe442ef3-5200-4b06-b4bc-fc0b495603a9.ttl
@@ -4,9 +4,10 @@ PREFIX solidtrees: <https://solidshapes.example/trees/>
 PREFIX alice-auth: <https://auth.alice.example/>
 
 alice-auth:fe442ef3-5200-4b06-b4bc-fc0b495603a9
-  a interop:RemoteDataGrant ;
+  a interop:DataConsent ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:accessMode acl:Read, acl:Write ;
-    interop:scopeOfGrant interop:InheritRemoteInstances ;
-    interop:inheritsFromGrant
+    interop:onDataOwnedBy <https://omni.example/#corp> ;
+    interop:scopeOfConsent interop:InheritRemoteInstances ;
+    interop:inheritsFromConsent
       alice-auth:329eb90a-feb9-4c95-a427-2ef23989abe9 .

--- a/proposals/primer/snippets/auth.omni.example/73c5f23c-099e-452e-ab29-cbfc8c8a19f8.ttl
+++ b/proposals/primer/snippets/auth.omni.example/73c5f23c-099e-452e-ab29-cbfc8c8a19f8.ttl
@@ -6,6 +6,7 @@ PREFIX omni-na: <https://na.omni.example/>
 
 omni-auth:73c5f23c-099e-452e-ab29-cbfc8c8a19f8
   a interop:DataGrant ;
+    interop:dataOwner <https://omni.example/#corp> ;
     interop:registeredShapeTree solidtrees:Task ;
     interop:hasDataRegistration omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/auth.omni.example/73c5f23c-099e-452e-ab29-cbfc8c8a19f8.ttl
+++ b/proposals/primer/snippets/auth.omni.example/73c5f23c-099e-452e-ab29-cbfc8c8a19f8.ttl
@@ -13,3 +13,6 @@ omni-auth:73c5f23c-099e-452e-ab29-cbfc8c8a19f8
     interop:scopeOfGrant interop:InheritInstances ;
     interop:inheritsFromGrant
       omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce .
+
+omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3
+  interop:iriPrefix "https://na.omni.example/" .

--- a/proposals/primer/snippets/auth.omni.example/a7f7d66d-13ba-4ba6-8908-3ea9c2703fce.ttl
+++ b/proposals/primer/snippets/auth.omni.example/a7f7d66d-13ba-4ba6-8908-3ea9c2703fce.ttl
@@ -11,6 +11,10 @@ omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce
     interop:hasDataRegistration omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140 ;
     interop:accessMode acl:Read, acl:Write ;
     interop:scopeOfGrant interop:AllInstances .
+
 omni-auth:73c5f23c-099e-452e-ab29-cbfc8c8a19f8
     interop:inheritsFromGrant
       omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce .
+
+omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140
+  interop:iriPrefix "https://na.omni.example/" .

--- a/proposals/primer/snippets/auth.omni.example/a7f7d66d-13ba-4ba6-8908-3ea9c2703fce.ttl
+++ b/proposals/primer/snippets/auth.omni.example/a7f7d66d-13ba-4ba6-8908-3ea9c2703fce.ttl
@@ -6,6 +6,7 @@ PREFIX omni-na: <https://na.omni.example/>
 
 omni-auth:a7f7d66d-13ba-4ba6-8908-3ea9c2703fce
   a interop:DataGrant ;
+    interop:dataOwner <https://omni.example/#corp> ;
     interop:registeredShapeTree solidtrees:Project ;
     interop:hasDataRegistration omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140 ;
     interop:accessMode acl:Read, acl:Write ;

--- a/proposals/primer/snippets/finance.acme.example/4f3fbf70-49df-47ce-a573-dc54366b01ad.ttl
+++ b/proposals/primer/snippets/finance.acme.example/4f3fbf70-49df-47ce-a573-dc54366b01ad.ttl
@@ -10,6 +10,7 @@ acme-finance:4f3fbf70-49df-47ce-a573-dc54366b01ad
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-08-23T21:12:45.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Task ;
+  interop:iriPrefix "https://finance.acme.example/" ;
   ldp:contains
     acme-finance:ea7a7621-b2fd-41b1-8992-c85d624f6bcc\#task ,
     acme-finance:ab6fd32b-ce6f-4c1e-baf3-0e42f1aae7e5\#task ,

--- a/proposals/primer/snippets/finance.acme.example/882eea27-b968-44e7-b8f5-87b234089057.ttl
+++ b/proposals/primer/snippets/finance.acme.example/882eea27-b968-44e7-b8f5-87b234089057.ttl
@@ -10,6 +10,7 @@ acme-finance:882eea27-b968-44e7-b8f5-87b234089057
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-08-23T21:12:27.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Project ;
+  interop:iriPrefix "https://finance.acme.example/" ;
   ldp:contains
     acme-finance:e7a5a287-9481-417e-91bf-40ea738fa737\#project ,
     acme-finance:c2883a4d-cece-43c2-9568-5f0aa1ac64be\#project .

--- a/proposals/primer/snippets/home.alice.example/92f43be4-d12c-4ca3-9bd6-c18e83167b2f.ttl
+++ b/proposals/primer/snippets/home.alice.example/92f43be4-d12c-4ca3-9bd6-c18e83167b2f.ttl
@@ -10,6 +10,7 @@ alice-home:92f43be4-d12c-4ca3-9bd6-c18e83167b2f
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-10-17T11:42:36.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Task ;
+  interop:iriPrefix "https://home.alice.example/" ;
   ldp:contains
     alice-home:f950bae5-247c-49b2-a537-b12cda8d5758\#task ,
     alice-home:46fea403-8605-473b-a9a1-a86f50fb1633\#task ,

--- a/proposals/primer/snippets/home.alice.example/f6ccd3a4-45ea-4f98-8a36-98eac92a6720.ttl
+++ b/proposals/primer/snippets/home.alice.example/f6ccd3a4-45ea-4f98-8a36-98eac92a6720.ttl
@@ -10,5 +10,6 @@ alice-home:f6ccd3a4-45ea-4f98-8a36-98eac92a6720
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-10-17T11:42:35.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Project ;
+  interop:iriPrefix "https://home.alice.example/" ;
   ldp:contains
     alice-home:0fd3daa3-dd6b-4484-826b-9ebaef099241\#project .

--- a/proposals/primer/snippets/na.omni.example/6b800a8a-1d53-45b5-81bd-e76f1a87bdd3.ttl
+++ b/proposals/primer/snippets/na.omni.example/6b800a8a-1d53-45b5-81bd-e76f1a87bdd3.ttl
@@ -10,6 +10,7 @@ omni-na:6b800a8a-1d53-45b5-81bd-e76f1a87bdd3
   interop:registeredWith <https://authbot.example/#bot> ;
   interop:registeredAt "2020-08-23T21:12:45.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Task ;
+  interop:iriPrefix "https://na.omni.example/" ;
   ldp:contains
     omni-na:79a1cc9e-e498-4a66-a2f8-9957a64e9488\#task ,
     omni-na:d2748fbd-565a-4a52-8709-b07a39f1fd4a\#task .

--- a/proposals/primer/snippets/na.omni.example/823e7976-13cc-4641-be0f-a4a78c2d7140.ttl
+++ b/proposals/primer/snippets/na.omni.example/823e7976-13cc-4641-be0f-a4a78c2d7140.ttl
@@ -10,5 +10,6 @@ omni-na:823e7976-13cc-4641-be0f-a4a78c2d7140
   interop:registeredWith <https://authbot.example/#bot> ;
   interop:registeredAt "2020-08-23T21:12:45.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Project ;
+  interop:iriPrefix "https://na.omni.example/" ;
   ldp:contains
     omni-na:30da889a-d65f-461d-ae52-50e19c77ed79\#project .

--- a/proposals/primer/snippets/pro.alice.example/4d594c61-7cff-484a-a1d2-1f353ee4e1e7.ttl
+++ b/proposals/primer/snippets/pro.alice.example/4d594c61-7cff-484a-a1d2-1f353ee4e1e7.ttl
@@ -10,6 +10,7 @@ alice-pro:4d594c61-7cff-484a-a1d2-1f353ee4e1e7
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-10-17T11:42:36.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Task ;
+  interop:iriPrefix "https://pro.alice.example/" ;
   ldp:contains
     alice-pro:576520a6-af5a-4cf9-8b40-8b1512b59c73\#task ,
     alice-pro:106a82aa-6911-4a7e-a49b-383cbaa9da66\#task ,

--- a/proposals/primer/snippets/pro.alice.example/773605f0-b5bf-4d46-878d-5c167eac8b5d.ttl
+++ b/proposals/primer/snippets/pro.alice.example/773605f0-b5bf-4d46-878d-5c167eac8b5d.ttl
@@ -10,6 +10,7 @@ alice-pro:773605f0-b5bf-4d46-878d-5c167eac8b5d
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-10-17T11:42:35.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Project ;
+  interop:iriPrefix "https://pro.alice.example/" ;
   ldp:contains
     alice-pro:ccbd77ae-f769-4e07-b41f-5136501e13e7\#project ,
     alice-pro:7a130c38-668a-4775-821a-08b38f2306fb\#project .

--- a/proposals/primer/snippets/rnd.acme.example/6e3b9ac3-254f-41cc-adbe-3f3293fd0475.ttl
+++ b/proposals/primer/snippets/rnd.acme.example/6e3b9ac3-254f-41cc-adbe-3f3293fd0475.ttl
@@ -10,6 +10,7 @@ acme-rnd:6e3b9ac3-254f-41cc-adbe-3f3293fd0475
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-08-23T21:12:27.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Project ;
+  interop:iriPrefix "https://rnd.acme.example/" ;
   ldp:contains
     acme-rnd:02c8217e-9933-4681-9fe3-f9d207a77a91\#project ,
     acme-rnd:18e75c28-3649-4c24-9e58-530df3813ca3\#project .

--- a/proposals/primer/snippets/rnd.acme.example/f56235d6-4e58-4492-97ec-42d3b5bfa539.ttl
+++ b/proposals/primer/snippets/rnd.acme.example/f56235d6-4e58-4492-97ec-42d3b5bfa539.ttl
@@ -10,6 +10,7 @@ acme-rnd:f56235d6-4e58-4492-97ec-42d3b5bfa539
   interop:registeredWith <https://solidmin.example/#app> ;
   interop:registeredAt "2020-08-23T21:12:45.000Z"^^xsd:dateTime ;
   interop:registeredShapeTree solidtrees:Task ;
+  interop:iriPrefix "https://rnd.acme.example/" ;
   ldp:contains
     acme-rnd:a51a89f5-0d4d-4213-9a9e-ea2dbadc56ea\#task ,
     acme-rnd:b51fb352-a098-4681-81aa-b655b9434932\#task ,

--- a/scripts/prepare-export.js
+++ b/scripts/prepare-export.js
@@ -5,8 +5,10 @@ SNIPPETS_PATH = 'proposals/primer/snippets'
 // TODO (elf-pavlik) adjust to handle bob.example
 IGNORE_HOSTS = [ 'solidshapes.example', 'bob.example' ]
 
-// delete existing dist
-fs.rmdirSync('dist',{ recursive: true })
+// delete existing dist if exists
+if (fs.existsSync('dist')) {
+  fs.rmdirSync('dist',{ recursive: true })
+}
 
 // create dist directory
 fs.mkdirSync('dist')


### PR DESCRIPTION
This PR includes following changes to snippets
* DataRegistration has explicit `interop:iriPrefix` used when creating new Data Instances
  * Any Data Grant for given registration includes statement from it with `interop:iriPrefix` #120
* Every Data Grant includes information about who owns the data `interop:dataOwner` #140
* Broad RemoteDataGrant is replaced with DataConsent and DelegatedDataGrant acts as copy of original Data Grant which can only narrow access mode further (later could also narrow data instances). #143 

[PR to TS implementation](https://github.com/janeirodigital/sai-js/pull/11) uses snippets here in its test suite 