### PR TITLE
Split out access needs from application profile in example

### DIFF
--- a/proposals/specification/access-needs.bs
+++ b/proposals/specification/access-needs.bs
@@ -75,12 +75,11 @@ used to communicate an access request to [=Social Agents=].
 
 <figure>
   <figcaption>An example [=Access Need Group=] for Projectron -
-  <a href="snippets/projectron.example/projectron.example.ttl">View</a></figcaption>  
-  </figcaption>  
+  <a href="snippets/projectron.example/needs.ttl">View</a></figcaption>
   <pre class=include-code>
-  path: snippets/projectron.example/projectron.example.ttl
+  path: snippets/projectron.example/needs.ttl
   highlight: turtle
-  show: 9-29
+  show: 6-35
   </pre> 
 </figure>
 
@@ -158,11 +157,11 @@ associating them with the [=Access Need=].
 
 <figure>
   <figcaption>[=Access Needs=] for Projects and Tasks in an [=Access Need Group=] for Projectron -
-  <a href="snippets/projectron.example/projectron.example.ttl">View</a></figcaption>
+  <a href="snippets/projectron.example/needs.ttl">View</a></figcaption>
   <pre class=include-code>
-  path: snippets/projectron.example/projectron.example.ttl
+  path: snippets/projectron.example/needs.ttl
   highlight: turtle
-  show: 17-45
+  show: 20-35
   </pre> 
 </figure>
 

--- a/proposals/specification/application.bs
+++ b/proposals/specification/application.bs
@@ -72,6 +72,6 @@ use any resource or subject names.
   <pre class=include-code>
   path: snippets/projectron.example/projectron.example.ttl
   highlight: turtle
-  show: 9-15
+  show: 10-17
   </pre> 
 </figure>

--- a/proposals/specification/snippets/projectron.example/needs.ttl
+++ b/proposals/specification/snippets/projectron.example/needs.ttl
@@ -1,0 +1,33 @@
+PREFIX interop: <http://www.w3.org/ns/solid/interop#>
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX projectron: <https://projectron.example/>
+PREFIX pm-shapetrees: <http://data.example/shapetrees/pm#>
+
+<#need-group-pm>
+  a interop:AccessNeedGroup ;
+  interop:accessNecessity interop:accessRequired ;
+  interop:accessScenario interop:PersonalAccess ;
+  interop:authenticatesAs interop:SocialAgent ;
+  interop:hasAccessDescriptionSet
+    projectron:access-en ,
+    projectron:access-es ,
+    projectron:access-nl ,
+    projectron:access-fr ,
+    projectron:access-ru ,
+    projectron:access-ko ;
+  interop:hasAccessNeed <#need-project> .
+
+<#need-project>
+  a interop:AccessNeed ;
+  interop:registeredShapeTree pm-shapetrees:ProjectTree ;
+  interop:accessNecessity interop:accessRequired ;
+  interop:accessMode acl:Read, acl:Create ;
+  interop:creatorAccessMode acl:Update, acl:Delete .
+
+<#need-task>
+  a interop:AccessNeed ;
+  interop:registeredShapeTree pm-shapetrees:TaskTree ;
+  interop:accessNecessity interop:accessRequired ;
+  interop:accessMode acl:Read, acl:Create ;
+  interop:creatorAccessMode acl:Update, acl:Delete ;
+  interop:inheritsFromNeed <#need-project> .

--- a/proposals/specification/snippets/projectron.example/projectron.example.ttl
+++ b/proposals/specification/snippets/projectron.example/projectron.example.ttl
@@ -2,6 +2,7 @@ PREFIX interop: <http://www.w3.org/ns/solid/interop#>
 PREFIX acl: <http://www.w3.org/ns/auth/acl#>
 PREFIX solidtrees: <https://shapetrees.example/solid/>
 PREFIX projectron: <https://projectron.example/>
+PREFIX needs: <https://projectron.example/needs#>
 PREFIX acme: <https://acme.example/>
 PREFIX pm: <https://vocab.example/pm/>
 PREFIX pm-shapetrees: <http://data.example/shapetrees/pm#>
@@ -12,33 +13,4 @@ projectron:\#id
   interop:applicationDescription "Manage projects with ease" ;
   interop:applicationAuthor acme:\#id ;
   interop:applicationThumbnail acme:thumb.svg ;
-  interop:hasAccessNeedGroup <#need-group-pm> .
-
-<#need-group-pm>
-  a interop:AccessNeedGroup ;
-  interop:accessNecessity interop:accessRequired ;
-  interop:accessScenario interop:PersonalAccess ;
-  interop:authenticatesAs interop:SocialAgent ;
-  interop:hasAccessDescriptionSet
-    projectron:access-en ,
-    projectron:access-es ,
-    projectron:access-nl ,
-    projectron:access-fr ,
-    projectron:access-ru ,
-    projectron:access-ko ;
-  interop:hasAccessNeed <#need-project> .
-
-<#need-project>
-  a interop:AccessNeed ;
-  interop:registeredShapeTree pm-shapetrees:ProjectTree ;
-  interop:accessNecessity interop:accessRequired ;
-  interop:accessMode acl:Read, acl:Create ;
-  interop:creatorAccessMode acl:Update, acl:Delete .
-
-<#need-task>
-  a interop:AccessNeed ;
-  interop:registeredShapeTree pm-shapetrees:TaskTree ;
-  interop:accessNecessity interop:accessRequired ;
-  interop:accessMode acl:Read, acl:Create ;
-  interop:creatorAccessMode acl:Update, acl:Delete ;
-  interop:inheritsFromNeed <#need-project> .
+  interop:hasAccessNeedGroup needs:need-group-pm .


### PR DESCRIPTION
Resolves #217. I don't think there was a need for any explicit normative language here, but I updated the projection example snippets to show access needs in a separate document to illustrate what should probably be best practice.