### PR TITLE
Fix Registry Set figure caption

### DIFF
--- a/proposals/specification/social-agent.bs
+++ b/proposals/specification/social-agent.bs
@@ -124,7 +124,7 @@ consented [=Applications=].
 </table>
 
 <figure>
-  <figcaption>[=Social Agent=] at https://alice.example/#id -
+  <figcaption>[=Registry Set=] at https://alice.example/registries -
   <a href="snippets/alice.example/registries.ttl">View</a>
   </figcaption>  
   <pre class=include-code>


### PR DESCRIPTION
Figure 2 in section 3.1 has the same caption as Figure 1. I figure (heh) that it was a copy/paste error.