### PR TITLE
Fix AccessNeedDescription pointing back to AccessNeedGroup

### DIFF
--- a/proposals/specification/access-needs.bs
+++ b/proposals/specification/access-needs.bs
@@ -249,9 +249,9 @@ a given [=Access Need=].
       <td>[=Access Description Set=] the description is part of</td>
     </tr>
     <tr>
-      <td>hasAccessNeedGroup</td>
-      <td>[AccessNeedGroup](#classAccessNeedGroup)</td>
-      <td>[=Access Need Group=] the description applies to</td>
+      <td>hasAccessNeed</td>
+      <td>[AccessNeed](#classAccessNeed)</td>
+      <td>[=Access Need=] the description applies to</td>
     </tr>
     <tr>
       <td>skos:prefLabel</td>

--- a/proposals/specification/interop.shex
+++ b/proposals/specification/interop.shex
@@ -110,7 +110,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 <#AccessNeedDescriptionShape> {
   a [ interop:AccessNeedDescription ] ;
   interop:inAccessDescriptionSet              IRI  // shex:reference <#AccessDescriptionSetShape> ;
-  interop:hasAccessNeedGroup                IRI  // shex:reference <#AccessNeedGroupShape> ;
+  interop:hasAccessNeed                     IRI  // shex:reference <#AccessNeedShape> ;
   skos:prefLabel xsd:string
 }
 


### PR DESCRIPTION
The shape and description table was pointing to AccessNeedGroup instead of AccessNeed. The snippet appears to be correct.