### PR TITLE
Update JSON-LD context with access consents, data consents, access grants, data grants

### DIFF
--- a/proposals/specification/interop.jsonld
+++ b/proposals/specification/interop.jsonld
@@ -122,7 +122,7 @@
       "@id": "interop:scopeOfGrant",
       "@type": "@id"
     },
-    "satisfiesAccessNed": {
+    "satisfiesAccessNeed": {
       "@id": "interop:satisfiesAccessNed",
       "@type": "@id"
     },


### PR DESCRIPTION
Adds support for [Access Consent Registry](https://deploy-preview-244--data-interoperability-panel.netlify.app/specification/#access-consent-registry), [Access Consents](https://deploy-preview-244--data-interoperability-panel.netlify.app/specification/#access-consent), [Data Consents](https://deploy-preview-244--data-interoperability-panel.netlify.app/specification/#data-consent), [Access Grants](https://deploy-preview-244--data-interoperability-panel.netlify.app/specification/#access-grant), [Data Grants](https://deploy-preview-244--data-interoperability-panel.netlify.app/specification/#data-grant), [Delegated Data Grants](https://deploy-preview-244--data-interoperability-panel.netlify.app/specification/#delegated-data-grant) to interop JSON-LD context.

Open question / note - for consistency I added another entry for "hasAccessNeedGroup", though we have a snake case version (has_access_need_group) that is specifically used in the client identifier document. We use this term in many other places, and seems like it would be nice to have it be consistent with others (camelCased) in those places. That said, what is the best practice in JSON-LD for a case like that?